### PR TITLE
support version increasing from golang module sub tags

### DIFF
--- a/version-update.py
+++ b/version-update.py
@@ -98,6 +98,8 @@ def main():
             print(latest)
             return 0
 
+        # if latest is a sub-tag (e.g. apm/v0.0.25), extract version (v0.0.25)
+        latest = latest[latest.find('/') + 1:]
         version = bump(latest)
 
     tag_repo(version)


### PR DESCRIPTION
when multiple modules are in one repo, golang looks for tag versions for the folders of the modules like `apm/v0.0.25`. This adds support for bumping the version number when the latest tag is a sub tag with a folder prefix.